### PR TITLE
Fix mobile toolbar collapse without breaking safe areas

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -43,12 +43,15 @@
 html,
 body {
   margin: 0;
+  height: auto; /* Разрешаем корневому документу тянуться естественно, чтобы скролл был на body. */
   /* порядок высот: сначала старый fallback, затем современные динамические */
   min-height: 100vh;
   min-height: 100svh;
   min-height: 100dvh;
   background: #000;
   color: #fff;
+  overflow-y: auto; /* Скролл переносится на корень — это нужно для автоскрытия тулбара iOS. */
+  overscroll-behavior-y: auto; /* Не блокируем жесты прокрутки, чтобы браузер мог свернуть панели. */
   /* iOS: раскрытые панели браузера остаются системным хромом — unsafe-зоны видны лишь при схлопнутых панелях или в PWA */
 }
 
@@ -59,21 +62,18 @@ body {
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+  padding: var(--safe-top) var(--safe-right) var(--safe-bottom) var(--safe-left);
+  /* Safe-area отступы теперь на корне, чтобы они обновлялись вместе со скроллом body. */
+  scroll-padding-top: calc(var(--safe-top) + 8px); /* Поддерживаем корректные якоря при схлопывании тулбара. */
+  scroll-padding-bottom: calc(var(--safe-bottom) + 8px);
 }
 
 .safe-frame {
   position: relative;
   display: flex;
   flex-direction: column;
-  /* Use padding instead of fixed insets so the root document scrolls and iOS can collapse
-     its toolbar while still honoring dynamic safe areas. */
   min-height: calc(var(--viewport-unit) * 100);
-  padding:
-    var(--safe-top)
-    var(--safe-right)
-    var(--safe-bottom)
-    var(--safe-left);
-  overflow: hidden;
+  overflow: visible; /* Не обрезаем контент, чтобы прокрутка происходила у body, а не во внутреннем контейнере. */
   contain: layout paint size;
   z-index: 0;
 }

--- a/styles.css
+++ b/styles.css
@@ -72,9 +72,13 @@ body {
   position: relative;
   display: flex;
   flex-direction: column;
+  /* Фолбэки на 100vh/svh/dvh сохраняют минимум контента для свайпа ещё до того, как скрипт обновит --viewport-unit. */
+  min-height: 100vh;
+  min-height: 100svh;
+  min-height: 100dvh;
   min-height: calc(var(--viewport-unit) * 100);
   overflow: visible; /* Не обрезаем контент, чтобы прокрутка происходила у body, а не во внутреннем контейнере. */
-  contain: layout paint size;
+  contain: layout paint; /* Убираем size-контейнмент: он фиксировал высоту .safe-frame на 100dvh и блокировал рост body, из-за чего iOS не видела скролл корня и не скрывала тулбар. */
   z-index: 0;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -62,13 +62,17 @@ body {
 }
 
 .safe-frame {
-  position: fixed;
-  top: var(--safe-top);
-  right: var(--safe-right);
-  bottom: var(--safe-bottom);
-  left: var(--safe-left);
+  position: relative;
   display: flex;
   flex-direction: column;
+  /* Use padding instead of fixed insets so the root document scrolls and iOS can collapse
+     its toolbar while still honoring dynamic safe areas. */
+  min-height: calc(var(--viewport-unit) * 100);
+  padding:
+    var(--safe-top)
+    var(--safe-right)
+    var(--safe-bottom)
+    var(--safe-left);
   overflow: hidden;
   contain: layout paint size;
   z-index: 0;
@@ -98,9 +102,6 @@ body.is-menu-closing {
 .safe-frame .content {
   position: relative;
   flex: 1 1 auto;
-  height: 100%;
-  overflow: auto;
-  -webkit-overflow-scrolling: touch;
 }
 
 .content {
@@ -332,7 +333,9 @@ body.is-menu-closing .site-menu {
 
 main {
   display: block;
-  min-height: 100vh;
+  /* Keep the primary flow sized to the dynamic viewport so browser chrome changes
+     don't freeze the first screen height. */
+  min-height: calc(var(--viewport-unit) * 100);
 }
 
 .site-header {
@@ -500,8 +503,14 @@ body.is-menu-closing .site-menu-toggle__icon span:nth-child(3) {
   width: min(920px, 100%);
   margin: 0 auto;
   padding-inline: clamp(24px, 8vw, 140px);
-  padding-block: clamp(48px, 22vh, 200px) clamp(200px, 52vh, 420px);
-  scroll-padding-block: clamp(48px, 22vh, 200px) clamp(200px, 52vh, 420px);
+  /* Use the dynamic viewport unit so the scroll padding adapts as the toolbar
+     expands or collapses, keeping reveal distances consistent. */
+  padding-block:
+    clamp(48px, calc(var(--viewport-unit) * 22), 200px)
+    clamp(200px, calc(var(--viewport-unit) * 52), 420px);
+  scroll-padding-block:
+    clamp(48px, calc(var(--viewport-unit) * 22), 200px)
+    clamp(200px, calc(var(--viewport-unit) * 52), 420px);
   perspective: 1400px;
 }
 
@@ -510,7 +519,9 @@ body.is-menu-closing .site-menu-toggle__icon span:nth-child(3) {
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 100vh;
+  /* Each card tracks the dynamic viewport height to guarantee a scrollable
+     surface large enough for iOS to trigger toolbar minimization. */
+  min-height: calc(var(--viewport-unit) * 100);
   text-align: center;
   font-size: clamp(28px, 5vw, 74px);
   line-height: 1.18;


### PR DESCRIPTION
## Summary
- allow the page to scroll by padding the safe-frame container instead of fixing it, keeping the dynamic safe area offsets intact
- tie the main narrative blocks to the dynamic viewport unit so iOS toolbar transitions no longer freeze the first screen height

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d84b09e0f483319483bc4886b6959c