### PR TITLE
Allow body scrolling while preserving safe-area layout

### DIFF
--- a/safe-area.js
+++ b/safe-area.js
@@ -1,48 +1,111 @@
 (function () {
   const root = document.documentElement;
-  const vv = window.visualViewport;
+  if (!root) return;
 
-  function update() {
-    const top = vv ? Math.max(0, vv.offsetTop) : null;
-    const bottom = vv
-      ? Math.max(0, window.innerHeight - (vv.height + vv.offsetTop))
-      : null;
-    const left = vv ? Math.max(0, vv.offsetLeft) : null;
-    const right = vv
-      ? Math.max(0, window.innerWidth - (vv.width + vv.offsetLeft))
-      : null;
+  const supportsEnv =
+    typeof CSS !== 'undefined' &&
+    CSS.supports('padding-bottom: env(safe-area-inset-bottom)');
+  const supportsConstant =
+    typeof CSS !== 'undefined' &&
+    CSS.supports('padding-bottom: constant(safe-area-inset-bottom)');
 
-    const computed = window.getComputedStyle(root);
-    const baseTop = parseFloat(computed.getPropertyValue('--safe-top-base')) || 0;
-    const baseBottom =
-      parseFloat(computed.getPropertyValue('--safe-bottom-base')) || 0;
-    const baseLeft = parseFloat(computed.getPropertyValue('--safe-left-base')) || 0;
-    const baseRight =
-      parseFloat(computed.getPropertyValue('--safe-right-base')) || 0;
+  const readComputedPx = (prop) => {
+    const raw = window.getComputedStyle(root).getPropertyValue(prop).trim();
+    const numeric = parseFloat(raw);
+    return Number.isFinite(numeric) ? numeric : 0;
+  };
 
-    function setVar(name, val) {
-      if (val == null) return;
-      const current = parseFloat(computed.getPropertyValue(name)) || 0;
-      if (Math.abs(current - val) > 0.5) {
-        root.style.setProperty(name, val + 'px');
-      }
-    }
+  const probeName = '--_safe-area-probe';
 
-    const resolvedTop = top == null ? baseTop : Math.max(baseTop, top);
-    const resolvedBottom = bottom == null ? baseBottom : Math.max(baseBottom, bottom);
-    const resolvedLeft = left == null ? baseLeft : Math.max(baseLeft, left);
-    const resolvedRight = right == null ? baseRight : Math.max(baseRight, right);
+  const readEnvPx = (token) => {
+    if (!supportsEnv) return 0;
+    root.style.setProperty(probeName, `env(${token})`);
+    const value = readComputedPx(probeName);
+    root.style.removeProperty(probeName);
+    return value;
+  };
 
-    setVar('--safe-top', resolvedTop);
-    setVar('--safe-bottom', resolvedBottom);
-    setVar('--safe-left', resolvedLeft);
-    setVar('--safe-right', resolvedRight);
+  const readConstantPx = (token) => {
+    if (!supportsConstant) return 0;
+    root.style.setProperty(probeName, `constant(${token})`);
+    const value = readComputedPx(probeName);
+    root.style.removeProperty(probeName);
+    return value;
+  };
+
+  let lastTop = 0;
+  let lastBottom = 0;
+  let lastLeft = 0;
+  let lastRight = 0;
+
+  const stick = (previous, next, floor) => {
+    if (next > 0) return next;
+    // When visualViewport collapses browser chrome it can momentarily report
+    // zero insets; keep the larger of the last real value and the system
+    // fallback instead of wiping padding to 0 and exposing unsafe areas.
+    return Math.max(previous, floor);
+  };
+
+  const calc = () => {
+    const vv = window.visualViewport;
+
+    const topFromVV = vv ? Math.max(0, vv.offsetTop) : 0;
+    const leftFromVV = vv ? Math.max(0, vv.offsetLeft) : 0;
+    const chromeGapY = vv
+      ? Math.max(0, window.innerHeight - vv.height - topFromVV)
+      : 0;
+    const chromeGapX = vv
+      ? Math.max(0, window.innerWidth - vv.width - leftFromVV)
+      : 0;
+
+    const envTop = readEnvPx('safe-area-inset-top');
+    const envBottom = readEnvPx('safe-area-inset-bottom');
+    const envLeft = readEnvPx('safe-area-inset-left');
+    const envRight = readEnvPx('safe-area-inset-right');
+
+    const constantTop = readConstantPx('safe-area-inset-top');
+    const constantBottom = readConstantPx('safe-area-inset-bottom');
+    const constantLeft = readConstantPx('safe-area-inset-left');
+    const constantRight = readConstantPx('safe-area-inset-right');
+
+    const floorTop = Math.max(envTop, constantTop);
+    const floorBottom = Math.max(envBottom, constantBottom);
+    const floorLeft = Math.max(envLeft, constantLeft);
+    const floorRight = Math.max(envRight, constantRight);
+
+    const nextTop = Math.max(topFromVV, floorTop);
+    const nextBottom = Math.max(chromeGapY, floorBottom);
+    const nextLeft = Math.max(leftFromVV, floorLeft);
+    const nextRight = Math.max(chromeGapX, floorRight);
+
+    lastTop = stick(lastTop, nextTop, floorTop);
+    lastBottom = stick(lastBottom, nextBottom, floorBottom);
+    lastLeft = stick(lastLeft, nextLeft, floorLeft);
+    lastRight = stick(lastRight, nextRight, floorRight);
+
+    root.style.setProperty('--safe-area-top', `${lastTop}px`);
+    root.style.setProperty('--safe-area-bottom', `${lastBottom}px`);
+    root.style.setProperty('--safe-area-left', `${lastLeft}px`);
+    root.style.setProperty('--safe-area-right', `${lastRight}px`);
+  };
+
+  let raf = null;
+  const schedule = () => {
+    if (raf != null) return;
+    raf = requestAnimationFrame(() => {
+      raf = null;
+      calc();
+    });
+  };
+
+  calc();
+
+  window.addEventListener('resize', schedule, { passive: true });
+  window.addEventListener('scroll', schedule, { passive: true });
+  window.addEventListener('orientationchange', schedule, { passive: true });
+
+  if (window.visualViewport) {
+    visualViewport.addEventListener('resize', schedule, { passive: true });
+    visualViewport.addEventListener('scroll', schedule, { passive: true });
   }
-
-  update();
-  if (vv) {
-    vv.addEventListener('resize', update);
-    vv.addEventListener('scroll', update);
-  }
-  window.addEventListener('orientationchange', update);
 })();

--- a/safe-area.js
+++ b/safe-area.js
@@ -4,22 +4,39 @@
 
   function update() {
     const top = vv ? Math.max(0, vv.offsetTop) : null;
-    const bottom = vv ? Math.max(0, window.innerHeight - (vv.height + vv.offsetTop)) : null;
+    const bottom = vv
+      ? Math.max(0, window.innerHeight - (vv.height + vv.offsetTop))
+      : null;
     const left = vv ? Math.max(0, vv.offsetLeft) : null;
-    const right = vv ? Math.max(0, window.innerWidth - (vv.width + vv.offsetLeft)) : null;
+    const right = vv
+      ? Math.max(0, window.innerWidth - (vv.width + vv.offsetLeft))
+      : null;
+
+    const computed = window.getComputedStyle(root);
+    const baseTop = parseFloat(computed.getPropertyValue('--safe-top-base')) || 0;
+    const baseBottom =
+      parseFloat(computed.getPropertyValue('--safe-bottom-base')) || 0;
+    const baseLeft = parseFloat(computed.getPropertyValue('--safe-left-base')) || 0;
+    const baseRight =
+      parseFloat(computed.getPropertyValue('--safe-right-base')) || 0;
 
     function setVar(name, val) {
       if (val == null) return;
-      const current = parseFloat(getComputedStyle(root).getPropertyValue(name)) || 0;
+      const current = parseFloat(computed.getPropertyValue(name)) || 0;
       if (Math.abs(current - val) > 0.5) {
         root.style.setProperty(name, val + 'px');
       }
     }
 
-    setVar('--safe-top', top);
-    setVar('--safe-bottom', bottom);
-    setVar('--safe-left', left);
-    setVar('--safe-right', right);
+    const resolvedTop = top == null ? baseTop : Math.max(baseTop, top);
+    const resolvedBottom = bottom == null ? baseBottom : Math.max(baseBottom, bottom);
+    const resolvedLeft = left == null ? baseLeft : Math.max(baseLeft, left);
+    const resolvedRight = right == null ? baseRight : Math.max(baseRight, right);
+
+    setVar('--safe-top', resolvedTop);
+    setVar('--safe-bottom', resolvedBottom);
+    setVar('--safe-left', resolvedLeft);
+    setVar('--safe-right', resolvedRight);
   }
 
   update();

--- a/script.js
+++ b/script.js
@@ -494,28 +494,124 @@
 
   if (!trigger || !container) return;
 
-  function getAbsoluteOffsetTop(element) {
-    let current = element;
-    let offset = 0;
+  const scrollContainer = container.closest('.content');
 
-    while (current) {
-      offset += current.offsetTop || 0;
-      current = current.offsetParent;
+  function resolveScrollElement() {
+    if (scrollContainer instanceof HTMLElement) {
+      const style = window.getComputedStyle(scrollContainer);
+      const overflowY = style.overflowY || style.overflow;
+      const hasScrollableOverflow = /(auto|scroll|overlay)/.test(overflowY);
+      const canScroll =
+        hasScrollableOverflow && scrollContainer.scrollHeight - scrollContainer.clientHeight > 1;
+
+      if (canScroll) {
+        return scrollContainer;
+      }
     }
 
-    return offset;
+    return document.scrollingElement || document.documentElement;
   }
+
+  const scrollElement = resolveScrollElement();
+  const isDocumentScrollElement =
+    scrollElement === document.documentElement || scrollElement === document.body;
 
   function clamp(value, min, max) {
     return Math.min(Math.max(value, min), max);
   }
 
+  function getScrollTop() {
+    if (isDocumentScrollElement) {
+      if (typeof window.pageYOffset === 'number') {
+        return window.pageYOffset;
+      }
+      if (scrollElement && typeof scrollElement.scrollTop === 'number') {
+        return scrollElement.scrollTop;
+      }
+      if (document.body && typeof document.body.scrollTop === 'number') {
+        return document.body.scrollTop;
+      }
+      return 0;
+    }
+
+    return scrollElement.scrollTop || 0;
+  }
+
+  function getScrollLeft() {
+    if (isDocumentScrollElement) {
+      if (typeof window.pageXOffset === 'number') {
+        return window.pageXOffset;
+      }
+      if (scrollElement && typeof scrollElement.scrollLeft === 'number') {
+        return scrollElement.scrollLeft;
+      }
+      if (document.body && typeof document.body.scrollLeft === 'number') {
+        return document.body.scrollLeft;
+      }
+      return 0;
+    }
+
+    return scrollElement.scrollLeft || 0;
+  }
+
+  function getViewportHeight() {
+    if (isDocumentScrollElement) {
+      return (
+        window.innerHeight ||
+        (document.documentElement && document.documentElement.clientHeight) ||
+        (document.body && document.body.clientHeight) ||
+        0
+      );
+    }
+
+    return scrollElement.clientHeight;
+  }
+
+  function getDocumentHeight() {
+    if (isDocumentScrollElement) {
+      return Math.max(
+        document.body.scrollHeight,
+        document.documentElement.scrollHeight,
+        document.body.offsetHeight,
+        document.documentElement.offsetHeight,
+        document.body.clientHeight,
+        document.documentElement.clientHeight
+      );
+    }
+
+    return scrollElement.scrollHeight;
+  }
+
+  function performScroll(left, top, behavior) {
+    const options = { left, top };
+    if (behavior) {
+      options.behavior = behavior;
+    }
+
+    if (isDocumentScrollElement) {
+      window.scrollTo(options);
+      return;
+    }
+
+    if (typeof scrollElement.scrollTo === 'function') {
+      scrollElement.scrollTo(options);
+    } else {
+      if (typeof left === 'number') {
+        scrollElement.scrollLeft = left;
+      }
+      if (typeof top === 'number') {
+        scrollElement.scrollTop = top;
+      }
+    }
+  }
+
   function animateScrollTo(top, duration) {
-    const currentX = window.scrollX || window.pageXOffset || 0;
-    const start = window.scrollY || window.pageYOffset || 0;
-    const distance = top - start;
+    const startX = getScrollLeft();
+    const startY = getScrollTop();
+    const distance = top - startY;
+
     if (distance === 0 || duration <= 0) {
-      window.scrollTo({ left: currentX, top });
+      performScroll(startX, top);
       return;
     }
 
@@ -528,7 +624,7 @@
       const elapsed = now - startTime;
       const progress = clamp(elapsed / duration, 0, 1);
       const eased = easeInOutCubic(progress);
-      window.scrollTo({ left: currentX, top: Math.round(start + distance * eased) });
+      performScroll(startX, Math.round(startY + distance * eased));
       if (progress < 1) {
         requestAnimationFrame(step);
       }
@@ -542,20 +638,20 @@
     const prefersReducedMotion =
       window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
-    const targetHeight = target.offsetHeight || target.getBoundingClientRect().height || 0;
-    const documentHeight = Math.max(
-      document.body.scrollHeight,
-      document.documentElement.scrollHeight,
-      document.body.offsetHeight,
-      document.documentElement.offsetHeight,
-      document.body.clientHeight,
-      document.documentElement.clientHeight
-    );
-
+    const viewportHeight = getViewportHeight();
+    const targetRect = target.getBoundingClientRect();
+    const targetHeight = targetRect.height || target.offsetHeight || 0;
+    const documentHeight = getDocumentHeight();
     const maxScroll = Math.max(0, documentHeight - viewportHeight);
 
-    let destination = getAbsoluteOffsetTop(target);
+    let destination;
+
+    if (isDocumentScrollElement) {
+      destination = getScrollTop() + targetRect.top;
+    } else {
+      const containerRect = scrollElement.getBoundingClientRect();
+      destination = scrollElement.scrollTop + (targetRect.top - containerRect.top);
+    }
 
     if (targetHeight < viewportHeight) {
       destination -= (viewportHeight - targetHeight) / 2;
@@ -564,7 +660,7 @@
     destination = clamp(destination, 0, maxScroll);
 
     if (prefersReducedMotion) {
-      window.scrollTo({ top: destination, behavior: 'auto' });
+      performScroll(getScrollLeft(), destination, 'auto');
       return;
     }
 

--- a/styles.css
+++ b/styles.css
@@ -15,10 +15,34 @@
   --safe-right-base: env(safe-area-inset-right, 0px);
   --safe-bottom-base: env(safe-area-inset-bottom, 0px);
   --safe-left-base: env(safe-area-inset-left, 0px);
-  --safe-top: var(--safe-top-base);
-  --safe-right: var(--safe-right-base);
-  --safe-bottom: var(--safe-bottom-base);
-  --safe-left: var(--safe-left-base);
+  --safe-top-legacy: 0px;
+  --safe-right-legacy: 0px;
+  --safe-bottom-legacy: 0px;
+  --safe-left-legacy: 0px;
+  --safe-area-top: var(--safe-top-base);
+  --safe-area-right: var(--safe-right-base);
+  --safe-area-bottom: var(--safe-bottom-base);
+  --safe-area-left: var(--safe-left-base);
+  --safe-top: max(
+    var(--safe-area-top, 0px),
+    var(--safe-top-base),
+    var(--safe-top-legacy)
+  );
+  --safe-right: max(
+    var(--safe-area-right, 0px),
+    var(--safe-right-base),
+    var(--safe-right-legacy)
+  );
+  --safe-bottom: max(
+    var(--safe-area-bottom, 0px),
+    var(--safe-bottom-base),
+    var(--safe-bottom-legacy)
+  );
+  --safe-left: max(
+    var(--safe-area-left, 0px),
+    var(--safe-left-base),
+    var(--safe-left-legacy)
+  );
   --content-bg: transparent;
 }
 
@@ -31,6 +55,15 @@
 @supports (height: 100svh) and not (height: 100dvh) {
   :root {
     --viewport-unit: 1svh;
+  }
+}
+
+@supports (padding-top: constant(safe-area-inset-top)) {
+  :root {
+    --safe-top-legacy: constant(safe-area-inset-top);
+    --safe-right-legacy: constant(safe-area-inset-right);
+    --safe-bottom-legacy: constant(safe-area-inset-bottom);
+    --safe-left-legacy: constant(safe-area-inset-left);
   }
 }
 
@@ -63,6 +96,8 @@ body {
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+  scroll-padding-top: calc(var(--safe-top) + 8px);
+  scroll-padding-bottom: calc(var(--safe-bottom) + 8px);
 }
 
 .safe-frame {

--- a/styles.css
+++ b/styles.css
@@ -62,15 +62,11 @@ body {
 }
 
 .safe-frame {
-  position: fixed;
-  top: var(--safe-top);
-  right: var(--safe-right);
-  bottom: var(--safe-bottom);
-  left: var(--safe-left);
+  position: relative;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
-  contain: layout paint size;
+  min-height: calc(var(--viewport-unit) * 100);
+  padding: var(--safe-top) var(--safe-right) var(--safe-bottom) var(--safe-left);
   z-index: 0;
 }
 
@@ -98,9 +94,6 @@ body.is-menu-closing {
 .safe-frame .content {
   position: relative;
   flex: 1 1 auto;
-  height: 100%;
-  overflow: auto;
-  -webkit-overflow-scrolling: touch;
 }
 
 .content {

--- a/styles.css
+++ b/styles.css
@@ -11,10 +11,14 @@
     'Helvetica Neue', 'Segoe UI', 'Inter', sans-serif;
   --font-serif: 'SF Pro Text', 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Segoe UI', 'Inter', sans-serif;
   --font-sans: 'SF Pro Display', 'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Segoe UI', 'Inter', sans-serif;
-  --safe-top: env(safe-area-inset-top, 0px);
-  --safe-right: env(safe-area-inset-right, 0px);
-  --safe-bottom: env(safe-area-inset-bottom, 0px);
-  --safe-left: env(safe-area-inset-left, 0px);
+  --safe-top-base: env(safe-area-inset-top, 0px);
+  --safe-right-base: env(safe-area-inset-right, 0px);
+  --safe-bottom-base: env(safe-area-inset-bottom, 0px);
+  --safe-left-base: env(safe-area-inset-left, 0px);
+  --safe-top: var(--safe-top-base);
+  --safe-right: var(--safe-right-base);
+  --safe-bottom: var(--safe-bottom-base);
+  --safe-left: var(--safe-left-base);
   --content-bg: transparent;
 }
 


### PR DESCRIPTION
## Summary
- let the safe-frame wrapper participate in normal document flow while preserving safe-area padding so browser chrome can collapse
- update the CTA scroll helper to target whichever element actually scrolls and reuse it for animated scrolling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8e06b597c8331a121e68b0caca3aa