### PR TITLE
Prevent safe area padding from collapsing

### DIFF
--- a/safe-area.js
+++ b/safe-area.js
@@ -1,31 +1,102 @@
 (function () {
   const root = document.documentElement;
+  const supportsCSS = typeof CSS !== 'undefined' && typeof CSS.supports === 'function';
+  const supportsEnv = supportsCSS && CSS.supports('padding-top: env(safe-area-inset-top)');
+  const supportsConstant = supportsCSS && CSS.supports('padding-top: constant(safe-area-inset-top)');
+
+  const readExpressionPx = (expression) => {
+    root.style.setProperty('--safe-area-probe', expression);
+    const raw = getComputedStyle(root).getPropertyValue('--safe-area-probe').trim();
+    root.style.removeProperty('--safe-area-probe');
+    const px = parseFloat(raw);
+    return Number.isFinite(px) ? px : 0;
+  };
+
+  const readEnvPx = (name) => {
+    let value = 0;
+    if (supportsEnv) {
+      value = Math.max(value, readExpressionPx(`env(${name})`));
+    }
+    if (supportsConstant) {
+      value = Math.max(value, readExpressionPx(`constant(${name})`));
+    }
+    return value;
+  };
+
+  const stick = (prev, next, env) => {
+    if (next > 0) {
+      return next;
+    }
+    // Когда visualViewport сообщает нули (UI браузера схлопнут),
+    // удерживаем максимум из предыдущего значения и системных env()/constant().
+    return Math.max(prev, env);
+  };
+
   const vv = window.visualViewport;
 
-  function update() {
-    const top = vv ? Math.max(0, vv.offsetTop) : null;
-    const bottom = vv ? Math.max(0, window.innerHeight - (vv.height + vv.offsetTop)) : null;
-    const left = vv ? Math.max(0, vv.offsetLeft) : null;
-    const right = vv ? Math.max(0, window.innerWidth - (vv.width + vv.offsetLeft)) : null;
+  let lastTop = readEnvPx('safe-area-inset-top');
+  let lastBottom = readEnvPx('safe-area-inset-bottom');
+  let lastLeft = readEnvPx('safe-area-inset-left');
+  let lastRight = readEnvPx('safe-area-inset-right');
 
-    function setVar(name, val) {
-      if (val == null) return;
-      const current = parseFloat(getComputedStyle(root).getPropertyValue(name)) || 0;
-      if (Math.abs(current - val) > 0.5) {
-        root.style.setProperty(name, val + 'px');
-      }
-    }
+  const setInset = (name, value) => {
+    root.style.setProperty(name, `${value}px`);
+  };
 
-    setVar('--safe-top', top);
-    setVar('--safe-bottom', bottom);
-    setVar('--safe-left', left);
-    setVar('--safe-right', right);
-  }
+  const applyInsets = () => {
+    const topFromVV = vv ? Math.max(0, vv.offsetTop) : 0;
+    const leftFromVV = vv ? Math.max(0, vv.offsetLeft) : 0;
+    const bottomFromVV = vv
+      ? Math.max(0, window.innerHeight - vv.height - topFromVV)
+      : 0;
+    const rightFromVV = vv
+      ? Math.max(0, window.innerWidth - vv.width - leftFromVV)
+      : 0;
 
-  update();
+    const envTop = readEnvPx('safe-area-inset-top');
+    const envBottom = readEnvPx('safe-area-inset-bottom');
+    const envLeft = readEnvPx('safe-area-inset-left');
+    const envRight = readEnvPx('safe-area-inset-right');
+
+    const nextTop = Math.max(topFromVV, envTop);
+    const nextBottom = Math.max(bottomFromVV, envBottom);
+    const nextLeft = Math.max(leftFromVV, envLeft);
+    const nextRight = Math.max(rightFromVV, envRight);
+
+    lastTop = stick(lastTop, nextTop, envTop);
+    lastBottom = stick(lastBottom, nextBottom, envBottom);
+    lastLeft = stick(lastLeft, nextLeft, envLeft);
+    lastRight = stick(lastRight, nextRight, envRight);
+
+    // Никогда не обнуляем safe-зоны: JS, env() и гистерезис дают устойчивый максимум.
+    setInset('--safe-area-top', lastTop);
+    setInset('--safe-area-bottom', lastBottom);
+    setInset('--safe-area-left', lastLeft);
+    setInset('--safe-area-right', lastRight);
+    // Поддерживаем старые переменные для совместимости существующих стилей.
+    setInset('--safe-top', lastTop);
+    setInset('--safe-bottom', lastBottom);
+    setInset('--safe-left', lastLeft);
+    setInset('--safe-right', lastRight);
+  };
+
+  let raf = null;
+  const schedule = () => {
+    if (raf) return;
+    raf = requestAnimationFrame(() => {
+      raf = null;
+      applyInsets();
+    });
+  };
+
+  applyInsets();
+
+  window.addEventListener('resize', schedule, { passive: true });
+  window.addEventListener('scroll', schedule, { passive: true });
+  window.addEventListener('orientationchange', schedule);
+
   if (vv) {
-    vv.addEventListener('resize', update);
-    vv.addEventListener('scroll', update);
+    vv.addEventListener('resize', schedule, { passive: true });
+    vv.addEventListener('scroll', schedule, { passive: true });
   }
-  window.addEventListener('orientationchange', update);
 })();

--- a/styles.css
+++ b/styles.css
@@ -15,6 +15,10 @@
   --safe-right: env(safe-area-inset-right, 0px);
   --safe-bottom: env(safe-area-inset-bottom, 0px);
   --safe-left: env(safe-area-inset-left, 0px);
+  --safe-area-top: var(--safe-top);
+  --safe-area-right: var(--safe-right);
+  --safe-area-bottom: var(--safe-bottom);
+  --safe-area-left: var(--safe-left);
   --content-bg: transparent;
 }
 
@@ -59,6 +63,19 @@ body {
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+  /* Двойной источник истины для safe-зон: JS-переменные + системные env()/constant(). */
+  padding-top: max(var(--safe-area-top, 0px), env(safe-area-inset-top), constant(safe-area-inset-top));
+  padding-bottom: max(
+    var(--safe-area-bottom, 0px),
+    env(safe-area-inset-bottom),
+    constant(safe-area-inset-bottom)
+  );
+  scroll-padding-top: calc(
+    max(var(--safe-area-top, 0px), env(safe-area-inset-top), constant(safe-area-inset-top)) + 8px
+  );
+  scroll-padding-bottom: calc(
+    max(var(--safe-area-bottom, 0px), env(safe-area-inset-bottom), constant(safe-area-inset-bottom)) + 8px
+  );
 }
 
 .safe-frame {


### PR DESCRIPTION
## Summary
- add CSS max fallbacks so body padding and scroll padding use both JS-calculated values and env()/constant() insets
- rewrite the safe area helper to combine visualViewport gaps with env values, apply sticky hysteresis, and throttle updates via rAF
- preserve existing custom properties while ensuring safe insets are never reset to zero when the browser UI collapses

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8eaf281c88331953936837243f444