### PR TITLE
Enable window scrolling while preserving safe areas

### DIFF
--- a/safe-area.js
+++ b/safe-area.js
@@ -2,17 +2,28 @@
   const root = document.documentElement;
   const vv = window.visualViewport;
 
+  const baseMap = {
+    '--safe-top': '--safe-top-env',
+    '--safe-bottom': '--safe-bottom-env',
+    '--safe-left': '--safe-left-env',
+    '--safe-right': '--safe-right-env'
+  };
+
   function update() {
     const top = vv ? Math.max(0, vv.offsetTop) : null;
     const bottom = vv ? Math.max(0, window.innerHeight - (vv.height + vv.offsetTop)) : null;
     const left = vv ? Math.max(0, vv.offsetLeft) : null;
     const right = vv ? Math.max(0, window.innerWidth - (vv.width + vv.offsetLeft)) : null;
+    const styles = getComputedStyle(root);
 
     function setVar(name, val) {
       if (val == null) return;
-      const current = parseFloat(getComputedStyle(root).getPropertyValue(name)) || 0;
-      if (Math.abs(current - val) > 0.5) {
-        root.style.setProperty(name, val + 'px');
+      const baseName = baseMap[name];
+      const base = baseName ? parseFloat(styles.getPropertyValue(baseName)) || 0 : 0;
+      const target = Math.max(base, val);
+      const current = parseFloat(styles.getPropertyValue(name)) || base;
+      if (Math.abs(current - target) > 0.5) {
+        root.style.setProperty(name, target + 'px');
       }
     }
 

--- a/script.js
+++ b/script.js
@@ -494,6 +494,12 @@
 
   if (!trigger || !container) return;
 
+  function getSafeInset(name) {
+    const styles = getComputedStyle(document.documentElement);
+    const value = parseFloat(styles.getPropertyValue(name));
+    return Number.isFinite(value) ? value : 0;
+  }
+
   function getAbsoluteOffsetTop(element) {
     let current = element;
     let offset = 0;
@@ -553,12 +559,17 @@
       document.documentElement.clientHeight
     );
 
+    const safeTop = getSafeInset('--safe-top');
+    const safeBottom = getSafeInset('--safe-bottom');
+    const safeViewport = Math.max(0, viewportHeight - safeTop - safeBottom);
     const maxScroll = Math.max(0, documentHeight - viewportHeight);
 
     let destination = getAbsoluteOffsetTop(target);
 
-    if (targetHeight < viewportHeight) {
-      destination -= (viewportHeight - targetHeight) / 2;
+    if (targetHeight < safeViewport) {
+      destination -= safeTop + (safeViewport - targetHeight) / 2;
+    } else {
+      destination -= safeTop;
     }
 
     destination = clamp(destination, 0, maxScroll);

--- a/styles.css
+++ b/styles.css
@@ -11,10 +11,14 @@
     'Helvetica Neue', 'Segoe UI', 'Inter', sans-serif;
   --font-serif: 'SF Pro Text', 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Segoe UI', 'Inter', sans-serif;
   --font-sans: 'SF Pro Display', 'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Segoe UI', 'Inter', sans-serif;
-  --safe-top: env(safe-area-inset-top, 0px);
-  --safe-right: env(safe-area-inset-right, 0px);
-  --safe-bottom: env(safe-area-inset-bottom, 0px);
-  --safe-left: env(safe-area-inset-left, 0px);
+  --safe-top-env: env(safe-area-inset-top, 0px);
+  --safe-right-env: env(safe-area-inset-right, 0px);
+  --safe-bottom-env: env(safe-area-inset-bottom, 0px);
+  --safe-left-env: env(safe-area-inset-left, 0px);
+  --safe-top: var(--safe-top-env);
+  --safe-right: var(--safe-right-env);
+  --safe-bottom: var(--safe-bottom-env);
+  --safe-left: var(--safe-left-env);
   --content-bg: transparent;
 }
 
@@ -52,6 +56,11 @@ body {
   /* iOS: раскрытые панели браузера остаются системным хромом — unsafe-зоны видны лишь при схлопнутых панелях или в PWA */
 }
 
+html {
+  scroll-padding-top: var(--safe-top);
+  scroll-padding-bottom: var(--safe-bottom);
+}
+
 body {
   position: relative;
   color: var(--text-strong);
@@ -62,15 +71,18 @@ body {
 }
 
 .safe-frame {
-  position: fixed;
-  top: var(--safe-top);
-  right: var(--safe-right);
-  bottom: var(--safe-bottom);
-  left: var(--safe-left);
+  position: relative;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
-  contain: layout paint size;
+  min-height: 100vh;
+  min-height: 100svh;
+  min-height: 100dvh;
+  min-height: calc(var(--viewport-unit) * 100);
+  padding-top: var(--safe-top);
+  padding-right: var(--safe-right);
+  padding-bottom: var(--safe-bottom);
+  padding-left: var(--safe-left);
+  box-sizing: border-box;
   z-index: 0;
 }
 
@@ -98,9 +110,7 @@ body.is-menu-closing {
 .safe-frame .content {
   position: relative;
   flex: 1 1 auto;
-  height: 100%;
-  overflow: auto;
-  -webkit-overflow-scrolling: touch;
+  min-height: max(0px, calc((var(--viewport-unit) * 100) - (var(--safe-top) + var(--safe-bottom))));
 }
 
 .content {


### PR DESCRIPTION
## Summary
- allow the page to scroll at the window level by replacing the fixed safe-frame wrapper with responsive safe-area padding
- clamp dynamic safe-area custom properties to the CSS env() fallbacks so unsafe regions stay protected
- update the scroll CTA logic to account for safe insets when choosing its destination

## Testing
- python -m http.server 8000 (for manual verification)

------
https://chatgpt.com/codex/tasks/task_e_68d8f2b3565c83318dce9cffbd82bd28