### PR TITLE
Rebuild homepage to mirror LoveFrom aesthetic

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,176 +1,89 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta
-    name="viewport"
-    content="width=device-width, initial-scale=1, viewport-fit=cover"
-  />
-  <title>CLASSNOE MESTO — Inspired Tribute</title>
-  <meta name="description" content="An homage to CLASSNOE MESTO's scrolling narrative experience." />
-  <meta property="og:title" content="CLASSNOE MESTO — Inspired Tribute" />
-  <meta property="og:description" content="An homage to CLASSNOE MESTO's scrolling narrative experience." />
-  <meta property="og:type" content="website" />
-  <meta name="apple-mobile-web-app-capable" content="yes" />
-  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-  <meta name="theme-color" content="#000000" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link
-    href="https://fonts.googleapis.com/css2?family=Outfit:wght@600;700&display=swap"
-    rel="stylesheet"
-  />
-  <link rel="stylesheet" href="./styles.css" />
-</head>
-<body>
-  <div class="safe-frame">
-    <div class="content">
-      <div class="backdrop" aria-hidden="true"></div>
-
-      <header class="site-header">
-        <div class="site-header__inner">
-          <div class="site-lockup">
-            <button
-              class="site-brand"
-              type="button"
-              data-scroll-to-sentences
-              aria-label="CLASSNOE MESTO — scroll to first message"
-            >
-              CLASSNOE MESTO
-            </button>
-          </div>
-          <button
-            class="site-menu-toggle"
-            type="button"
-            data-menu-toggle
-            aria-expanded="false"
-            aria-controls="site-menu"
-            aria-label="Open menu"
-          >
-            <span class="site-menu-toggle__icon" aria-hidden="true">
-              <span></span>
-              <span></span>
-              <span></span>
-            </span>
-          </button>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>LoveFrom — Creative Collective</title>
+    <meta
+      name="description"
+      content="A faithful recreation of LoveFrom's minimal homepage for a private deployment."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;600&family=Work+Sans:wght@300;400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <div class="page">
+      <header class="hero" aria-labelledby="hero-title">
+        <div class="hero__logo" aria-hidden="true">LoveFrom</div>
+        <div class="hero__copy">
+          <h1 id="hero-title">LoveFrom is a creative collective.</h1>
+          <p>
+            We are designers, architects, writers, engineers and artists. We collaborate with founders and
+            leaders who are driven to create the future and care deeply about craft, beauty and ingenuity.
+          </p>
+          <p>
+            Our studio was founded by Sir Jony Ive and Marc Newson. Together with our partners and
+            collaborators we work across product, digital, spatial and identity design.
+          </p>
         </div>
       </header>
 
-      <div
-        id="site-menu"
-        class="site-menu"
-        role="dialog"
-        aria-modal="true"
-        aria-label="Site navigation"
-        aria-hidden="true"
-        hidden
-      >
-        <div class="site-menu__backdrop" data-menu-close></div>
-        <div class="site-menu__container" role="document" tabindex="-1" data-menu-focus>
-          <nav class="site-menu__nav" aria-label="Primary">
-            <ul class="site-menu__list" role="list">
-              <li class="site-menu__item">
-                <a href="#content" class="site-menu__link" data-menu-link>Branding</a>
-              </li>
-              <li class="site-menu__item">
-                <a href="#content" class="site-menu__link" data-menu-link>Packaging</a>
-              </li>
-              <li class="site-menu__item">
-                <a href="#content" class="site-menu__link" data-menu-link>Social Media</a>
-              </li>
-              <li class="site-menu__item">
-                <a href="#content" class="site-menu__link" data-menu-link>Templates</a>
-              </li>
-              <li class="site-menu__item">
-                <a href="#content" class="site-menu__link" data-menu-link>Web Design</a>
-              </li>
-              <li class="site-menu__item">
-                <a href="#content" class="site-menu__link" data-menu-link>Monthly Design</a>
-              </li>
-            </ul>
-          </nav>
+      <main class="content" aria-labelledby="content-heading">
+        <h2 id="content-heading">Practices</h2>
+        <div class="grid">
+          <section class="card">
+            <h3>Product</h3>
+            <p>
+              Industrial and digital products built in close partnership with ambitious teams. From early
+              concept to refined execution, we pursue thoughtful outcomes that feel inevitable.
+            </p>
+          </section>
+          <section class="card">
+            <h3>Brand</h3>
+            <p>
+              Identity systems, typography and narratives that express the essential character of a company or
+              idea. Our work spans naming, voice, visual identity and launch experiences.
+            </p>
+          </section>
+          <section class="card">
+            <h3>Spatial</h3>
+            <p>
+              Architectural collaborations and crafted environments that invite curiosity and calm. We design
+              exhibitions, installations and retail spaces with a focus on material honesty.
+            </p>
+          </section>
+          <section class="card">
+            <h3>Collaborations</h3>
+            <p>
+              Partnerships with organisations that share our fascination with creativity and invention. We
+              mentor, advise and build enduring relationships with founders and cultural institutions.
+            </p>
+          </section>
         </div>
-      </div>
-
-      <main id="content" aria-labelledby="content-title">
-        <h1 id="content-title" class="visually-hidden">CLASSNOE MESTO inspired narrative</h1>
-        <section id="sentences" role="list" aria-live="polite"></section>
       </main>
 
-      <footer class="site-footer" aria-label="Footer">
-        <div class="site-footer__inner">
-          <div class="site-footer__column">
+      <footer class="footer" aria-label="Contact">
+        <div class="footer__inner">
+          <div class="footer__column">
             <h2>Inquiries</h2>
-            <a href="mailto:hello@classnoemesto.com">hello@classnoemesto.com</a>
+            <a href="mailto:studio@lovefrom.com">studio@lovefrom.com</a>
           </div>
-          <div class="site-footer__column">
+          <div class="footer__column">
             <h2>Press</h2>
-            <a href="mailto:press@classnoemesto.com">press@classnoemesto.com</a>
+            <a href="mailto:press@lovefrom.com">press@lovefrom.com</a>
           </div>
-          <div class="site-footer__column">
+          <div class="footer__column">
             <h2>Follow</h2>
-            <a
-              href="https://www.instagram.com/classnoemesto/"
-              target="_blank"
-              rel="noreferrer noopener"
-            >Instagram</a>
+            <a href="https://www.instagram.com/lovefrom/" target="_blank" rel="noreferrer noopener">Instagram</a>
           </div>
         </div>
+        <p class="footer__note">© LoveFrom. All rights reserved.</p>
       </footer>
     </div>
-    <pre
-      id="safe-debug"
-      style="position:fixed;left:calc(var(--safe-left) + 8px);bottom:calc(var(--safe-bottom) + 8px);padding:6px 8px;background:rgba(0,0,0,.6);color:#0f0;font:12px/1.4 ui-monospace,Menlo,Consolas,monospace;z-index:99999;border-radius:6px;"
-    ></pre>
-  </div>
-
-  <script src="./safe-area.js"></script>
-  <script>
-    (function () {
-      const qs = new URLSearchParams(location.search);
-      if (qs.get('safetest') === '1') {
-        document.documentElement.classList.add('safe-test');
-      }
-    })();
-  </script>
-  <script>
-    const SENTENCES = [
-      "CLASSNOE MESTO is a creative collective of designers, architects, musicians, filmmakers, writers, and engineers.",
-      "We are fascinated by the traditions of craft and defined by the pursuit of excellence.",
-      "We imagine and build products, experiences, and organizations in close partnership with leaders we admire.",
-      "Our curiosity leads us to learn, to question, and to design with a respect for materials and for the people who use them.",
-      "We work from Saint Petersburg, collaborating around the world on projects that make life a little more thoughtful."
-    ];
-    window.SITE_CONFIG = { SENTENCES };
-    console.log(getComputedStyle(document.documentElement).getPropertyValue('--safe-top'));
-    console.log(getComputedStyle(document.documentElement).getPropertyValue('--safe-bottom'));
-  </script>
-  <script defer src="./script.js"></script>
-  <script>
-    (function () {
-      const qs = new URLSearchParams(location.search);
-      if (!qs.has('debug') || qs.get('debug') !== 'safe') {
-        const dbg = document.getElementById('safe-debug');
-        if (dbg) dbg.remove();
-        return;
-      }
-      function dump() {
-        const cs = getComputedStyle(document.documentElement);
-        const t = cs.getPropertyValue('--safe-top').trim();
-        const r = cs.getPropertyValue('--safe-right').trim();
-        const b = cs.getPropertyValue('--safe-bottom').trim();
-        const l = cs.getPropertyValue('--safe-left').trim();
-        document.getElementById('safe-debug').textContent =
-          `safe-top: ${t}\nsafe-right: ${r}\nsafe-bottom: ${b}\nsafe-left: ${l}`;
-      }
-      dump();
-      window.addEventListener('resize', dump);
-      window.addEventListener('orientationchange', dump);
-      if (window.visualViewport) {
-        visualViewport.addEventListener('resize', dump);
-        visualViewport.addEventListener('scroll', dump);
-      }
-    })();
-  </script>
-</body>
+  </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,33 +1,13 @@
 :root {
   color-scheme: dark;
   --background: #050505;
-  --text-strong: rgba(255, 255, 255, 0.995);
-  --text-muted: rgba(255, 255, 255, 0.88);
-  --text-subtle: rgba(255, 255, 255, 0.6);
-  --text-faint: rgba(255, 255, 255, 0.26);
-  --viewport-unit: 1vh;
-  --overscroll-bleed: clamp(120px, calc(var(--viewport-unit) * 16), 240px);
-  --font-brand: 'Outfit', 'SF Pro Display', 'SF Pro Text', -apple-system, BlinkMacSystemFont,
-    'Helvetica Neue', 'Segoe UI', 'Inter', sans-serif;
-  --font-serif: 'SF Pro Text', 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Segoe UI', 'Inter', sans-serif;
-  --font-sans: 'SF Pro Display', 'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Segoe UI', 'Inter', sans-serif;
-  --safe-top: env(safe-area-inset-top, 0px);
-  --safe-right: env(safe-area-inset-right, 0px);
-  --safe-bottom: env(safe-area-inset-bottom, 0px);
-  --safe-left: env(safe-area-inset-left, 0px);
-  --content-bg: transparent;
-}
-
-@supports (height: 100dvh) {
-  :root {
-    --viewport-unit: 1dvh;
-  }
-}
-
-@supports (height: 100svh) and not (height: 100dvh) {
-  :root {
-    --viewport-unit: 1svh;
-  }
+  --foreground: rgba(255, 255, 255, 0.92);
+  --muted: rgba(255, 255, 255, 0.68);
+  --accent: rgba(255, 255, 255, 0.16);
+  --hero-size: clamp(2.8rem, 7vw, 4.5rem);
+  --body-size: clamp(1rem, 2vw, 1.125rem);
+  --mono: 'Work Sans', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --serif: 'Playfair Display', 'Times New Roman', serif;
 }
 
 *,
@@ -36,631 +16,182 @@
   box-sizing: border-box;
 }
 
-[hidden] {
-  display: none !important;
-}
-
-html,
 body {
   margin: 0;
-  /* порядок высот: сначала старый fallback, затем современные динамические */
   min-height: 100vh;
-  min-height: 100svh;
-  min-height: 100dvh;
-  background: #000;
-  color: #fff;
-  /* iOS: раскрытые панели браузера остаются системным хромом — unsafe-зоны видны лишь при схлопнутых панелях или в PWA */
-}
-
-body {
-  position: relative;
-  color: var(--text-strong);
-  font-family: var(--font-serif);
-  line-height: 1.5;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.04), transparent 45%),
+    radial-gradient(circle at 80% 0%, rgba(255, 255, 255, 0.08), transparent 50%),
+    radial-gradient(circle at 60% 90%, rgba(255, 255, 255, 0.05), transparent 40%),
+    var(--background);
+  color: var(--foreground);
+  font-family: var(--mono);
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }
 
-.safe-frame {
-  position: fixed;
-  top: var(--safe-top);
-  right: var(--safe-right);
-  bottom: var(--safe-bottom);
-  left: var(--safe-left);
+.page {
   display: flex;
   flex-direction: column;
-  overflow: hidden;
-  contain: layout paint size;
-  z-index: 0;
+  min-height: 100vh;
+  padding: clamp(24px, 5vw, 64px);
+  gap: clamp(3rem, 7vw, 6rem);
 }
 
-.safe-frame::before {
-  content: '';
-  position: fixed;
-  top: 0;
-  right: var(--safe-right);
-  left: var(--safe-left);
-  height: var(--safe-top);
-  background-image: linear-gradient(
-    to top,
-    var(--content-bg, var(--background, #000)) 0%,
-    #000 100%
-  );
-  pointer-events: none;
-  z-index: 1;
+.hero {
+  display: grid;
+  gap: clamp(2rem, 6vw, 6rem);
+  grid-template-columns: minmax(200px, 1fr) minmax(240px, 2fr);
+  align-items: center;
 }
 
-body.has-menu-open,
-body.is-menu-closing {
-  overflow: hidden;
+.hero__logo {
+  font-family: var(--serif);
+  font-size: clamp(4rem, 12vw, 8.5rem);
+  font-weight: 500;
+  letter-spacing: 0.14rem;
+  text-transform: uppercase;
+  line-height: 0.9;
+  color: var(--foreground);
 }
 
-.safe-frame .content {
-  position: relative;
-  flex: 1 1 auto;
-  height: 100%;
-  overflow: auto;
-  -webkit-overflow-scrolling: touch;
+.hero__copy {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.hero__copy h1 {
+  font-family: var(--serif);
+  font-size: var(--hero-size);
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  margin: 0;
+}
+
+.hero__copy p {
+  margin: 0;
+  font-size: var(--body-size);
+  line-height: 1.7;
+  color: var(--muted);
+  max-width: 52ch;
 }
 
 .content {
-  box-sizing: border-box;
-  min-height: 100vh;
-  min-height: 100svh;
-  min-height: 100dvh;
-  min-height: calc((var(--viewport-unit) * 100) - (var(--safe-top) + var(--safe-bottom)));
-  padding: 16px;
-  background: var(--content-bg);
-}
-
-.visually-hidden {
-  position: absolute !important;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
-body::before {
-  content: '';
-  position: fixed;
-  inset: calc(var(--overscroll-bleed) * -1);
-  background: radial-gradient(120% 70% at 50% 0%, rgba(255, 244, 230, 0.1), rgba(5, 5, 5, 0)),
-    radial-gradient(80% 60% at 80% 25%, rgba(248, 230, 210, 0.08), rgba(5, 5, 5, 0)),
-    radial-gradient(120% 60% at 20% 80%, rgba(245, 220, 200, 0.08), rgba(5, 5, 5, 0));
-  opacity: 0.85;
-  pointer-events: none;
-  z-index: 0;
-}
-
-body::after {
-  content: '';
-  position: fixed;
-  inset: calc(var(--overscroll-bleed) * -1) 0;
-  pointer-events: none;
-  z-index: 2;
-  background-image:
-    linear-gradient(to bottom, rgba(5, 5, 5, 0.9) 0%, rgba(5, 5, 5, 0) 60%),
-    linear-gradient(to top, rgba(5, 5, 5, 0.9) 0%, rgba(5, 5, 5, 0) 60%),
-    linear-gradient(
-      to top,
-      rgba(5, 5, 5, 0.88) 0%,
-      rgba(5, 5, 5, 0.52) 45%,
-      rgba(5, 5, 5, 0.18) 85%,
-      rgba(5, 5, 5, 0) 100%
-    );
-  background-position:
-    center var(--overscroll-bleed),
-    center calc(100% - var(--overscroll-bleed)),
-    center calc(100% - var(--overscroll-bleed));
-  background-repeat: no-repeat;
-  background-size:
-    100% clamp(160px, calc(var(--viewport-unit) * 34), 360px),
-    100% clamp(160px, calc(var(--viewport-unit) * 34), 360px),
-    100% clamp(200px, calc(var(--viewport-unit) * 42), 420px);
-}
-
-html.safe-test,
-html.safe-test body {
-  background:
-    repeating-linear-gradient(to bottom, #000 0, #000 8px, #111 8px, #111 16px);
-}
-
-html.safe-test body::before,
-html.safe-test body::after {
-  display: none;
-}
-
-.backdrop {
-  position: fixed;
-  inset: calc(var(--overscroll-bleed) * -1) 0;
-  background: rgba(5, 5, 5, 0.82);
-  pointer-events: none;
-  z-index: 0;
-}
-
-.backdrop::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  opacity: 0.12;
-  mix-blend-mode: screen;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='240' height='240'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.5'/%3E%3C/svg%3E");
-  background-size: 200px;
-}
-
-main,
-header,
-footer {
-  position: relative;
-  z-index: 1;
-}
-
-main,
-header,
-footer,
-.backdrop {
-  transition: filter 500ms ease-in-out, opacity 500ms ease-in-out;
-}
-
-body.has-menu-open main,
-body.has-menu-open footer,
-body.has-menu-open .backdrop,
-body.is-menu-closing main,
-body.is-menu-closing footer,
-body.is-menu-closing .backdrop {
-  filter: blur(28px);
-  opacity: 0.2;
-}
-
-body.has-menu-open .site-header,
-body.is-menu-closing .site-header {
-  pointer-events: none;
-}
-
-body.has-menu-open .site-menu-toggle,
-body.is-menu-closing .site-menu-toggle {
-  pointer-events: auto;
-}
-
-.site-menu {
-  position: fixed;
-  top: calc(var(--safe-top) - var(--overscroll-bleed));
-  right: var(--safe-right);
-  bottom: calc(var(--safe-bottom) - var(--overscroll-bleed));
-  left: var(--safe-left);
   display: grid;
-  place-items: center;
-  padding:
-    calc(var(--overscroll-bleed) + clamp(32px, 6vw, 96px))
-    clamp(32px, 6vw, 96px)
-    calc(var(--overscroll-bleed) + clamp(32px, 6vw, 96px))
-    clamp(32px, 6vw, 96px);
-  background: rgba(5, 5, 5, 0.82);
-  backdrop-filter: blur(28px);
-  z-index: 10;
-  opacity: 0;
-  pointer-events: none;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  -webkit-overflow-scrolling: touch;
-  transition: opacity 500ms ease-in-out;
+  gap: clamp(2rem, 5vw, 4rem);
 }
 
-body.has-menu-open .site-menu,
-.site-menu.is-open {
-  opacity: 1;
-  pointer-events: auto;
-}
-
-body.is-menu-closing .site-menu {
-  opacity: 0;
-  pointer-events: none;
-}
-
-.site-menu__backdrop {
-  position: absolute;
-  inset: 0;
-  cursor: pointer;
-}
-
-
-.site-menu__container {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: clamp(28px, 4vw, 48px);
-  width: min(880px, 100%);
-  padding: clamp(40px, 7vw, 76px) clamp(36px, 7vw, 84px);
-  border-radius: clamp(28px, 6vw, 48px);
-  background: rgba(8, 8, 8, 0.82);
-  box-shadow: 0 32px 120px rgba(0, 0, 0, 0.6);
-  pointer-events: auto;
-  margin-block: clamp(40px, 10vh, 160px);
-}
-
-.site-menu__container:focus,
-.site-menu__container:focus-visible {
-  outline: none;
-}
-
-.site-menu__nav {
-  display: block;
-}
-
-.site-menu__list {
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: clamp(20px, 3.6vw, 44px);
-  margin: 0;
-  padding: 0;
-}
-
-.site-menu__item {
-  margin: 0;
-  padding: 0;
-}
-
-.site-menu__link {
-  display: inline-flex;
-  align-items: center;
-  font-family: var(--font-sans);
-  font-size: clamp(22px, 3.6vw, 44px);
-  font-weight: 600;
+.content h2 {
+  font-family: var(--serif);
+  font-weight: 500;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.94);
-  text-decoration: none;
-  transition: color 200ms ease, transform 220ms ease;
-}
-
-.site-menu__link:hover,
-.site-menu__link:focus-visible {
-  color: rgba(255, 255, 255, 1);
-  transform: translateX(10px);
-}
-
-.site-menu__link:focus-visible {
-  outline: none;
-  text-shadow: 0 0 22px rgba(255, 255, 255, 0.35);
-}
-
-main {
-  display: block;
-  min-height: 100vh;
-}
-
-.site-header {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  min-height: calc(var(--viewport-unit) * 100);
-  padding: clamp(32px, 8vh, 96px) clamp(24px, 6vw, 60px);
-  z-index: 32;
-}
-
-.site-header__inner {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: clamp(16px, 3vw, 36px);
-  width: min(960px, 100%);
-  pointer-events: auto;
-  text-align: center;
-}
-
-.site-lockup {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: clamp(8px, 1.6vw, 16px);
-  transition: opacity 360ms ease-in-out, transform 360ms ease-in-out;
-}
-
-body.has-menu-open .site-lockup,
-body.is-menu-closing .site-lockup {
-  opacity: 0;
-  transform: translateY(-8px);
-  pointer-events: none;
-}
-
-.site-brand {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+  font-size: clamp(1.25rem, 3vw, 1.75rem);
   margin: 0;
-  padding: 0;
-  border: none;
-  background: none;
-  appearance: none;
-  cursor: pointer;
-  font-family: var(--font-brand);
-  font-size: clamp(21.6px, 5.4vw, 57.6px);
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  line-height: 1.05;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.995);
-  text-shadow: 0 0 32px rgba(255, 255, 255, 0.28);
-  text-align: center;
-  white-space: nowrap;
-  transition: color 200ms ease;
+  color: rgba(255, 255, 255, 0.8);
 }
 
-.site-brand:hover {
-  color: rgba(255, 255, 255, 1);
-}
-
-.site-brand:focus-visible {
-  outline: none;
-  color: rgba(255, 255, 255, 1);
-  text-shadow: 0 0 26px rgba(255, 255, 255, 0.35);
-}
-
-.site-menu-toggle {
-  position: fixed;
-  top: calc(var(--safe-top) + clamp(24px, 4vw, 48px));
-  right: calc(var(--safe-right) + clamp(24px, 4vw, 48px));
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: clamp(52px, 5vw, 68px);
-  height: clamp(52px, 5vw, 68px);
-  margin: 0;
-  padding: 0;
-  border: none;
-  background: none;
-  color: rgba(255, 255, 255, 0.96);
-  cursor: pointer;
-  z-index: 40;
-  transition: color 340ms ease;
-}
-
-.site-menu-toggle:hover,
-.site-menu-toggle:focus-visible {
-  color: rgba(255, 255, 255, 0.995);
-}
-
-.site-menu-toggle:focus-visible {
-  outline: none;
-}
-
-body.has-menu-open .site-menu-toggle,
-body.is-menu-closing .site-menu-toggle {
-  color: rgba(255, 255, 255, 0.995);
-}
-
-.site-menu-toggle:focus-visible .site-menu-toggle__icon span {
-  box-shadow: 0 0 16px rgba(255, 255, 255, 0.38);
-}
-
-.site-menu-toggle__icon {
-  position: relative;
-  width: clamp(22px, 2.3vw, 32px);
-  height: clamp(16px, 2vw, 24px);
-}
-
-.site-menu-toggle__icon span {
-  position: absolute;
-  left: 0;
-  width: 100%;
-  height: clamp(2px, 0.28vw, 3px);
-  border-radius: 999px;
-  background: currentColor;
-  transform-origin: center;
-  transition: transform 480ms cubic-bezier(0.34, 1.56, 0.64, 1), opacity 320ms ease;
-}
-
-.site-menu-toggle__icon span:nth-child(1) {
-  top: 0;
-}
-
-.site-menu-toggle__icon span:nth-child(2) {
-  top: 50%;
-  transform: translateY(-50%);
-}
-
-.site-menu-toggle__icon span:nth-child(3) {
-  bottom: 0;
-}
-
-body.has-menu-open .site-menu-toggle__icon span:nth-child(1),
-body.is-menu-closing .site-menu-toggle__icon span:nth-child(1) {
-  top: 50%;
-  transform: translateY(-50%) rotate(45deg);
-}
-
-body.has-menu-open .site-menu-toggle__icon span:nth-child(2),
-body.is-menu-closing .site-menu-toggle__icon span:nth-child(2) {
-  opacity: 0;
-  transform: translateY(-50%) scaleX(0.4);
-}
-
-body.has-menu-open .site-menu-toggle__icon span:nth-child(3),
-body.is-menu-closing .site-menu-toggle__icon span:nth-child(3) {
-  bottom: auto;
-  top: 50%;
-  transform: translateY(-50%) rotate(-45deg);
-}
-
-#sentences {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  width: min(920px, 100%);
-  margin: 0 auto;
-  padding-inline: clamp(24px, 8vw, 140px);
-  padding-block: clamp(48px, 22vh, 200px) clamp(200px, 52vh, 420px);
-  scroll-padding-block: clamp(48px, 22vh, 200px) clamp(200px, 52vh, 420px);
-  perspective: 1400px;
-}
-
-.sentence {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 100vh;
-  text-align: center;
-  font-size: clamp(28px, 5vw, 74px);
-  line-height: 1.18;
-  letter-spacing: -0.015em;
-  font-weight: 500;
-  color: var(--text-faint);
-  opacity: 0;
-  filter: blur(28px);
-  transform: translate3d(0, 160px, -280px) scale(0.88);
-  transition:
-    opacity 760ms ease,
-    filter 760ms ease,
-    transform 880ms cubic-bezier(0.22, 0.61, 0.36, 1),
-    color 620ms ease;
-  will-change: opacity, transform, filter, color;
-  text-wrap: balance;
-}
-
-.sentence.is-visible {
-  opacity: 0.5;
-  color: rgba(255, 255, 255, 0.62);
-  filter: blur(16px);
-  transform: translate3d(0, 80px, -160px) scale(0.92);
-}
-
-.sentence.is-past {
-  opacity: 0.36;
-  color: rgba(255, 255, 255, 0.38);
-  filter: blur(18px);
-  transform: translate3d(0, -60px, -220px) scale(0.9);
-}
-
-.sentence.is-active {
-  opacity: 1;
-  color: var(--text-strong);
-  filter: blur(0);
-  transform: translate3d(0, 0, 0) scale(1);
-}
-
-.site-footer {
-  padding:
-    clamp(80px, 18vh, 140px)
-    clamp(24px, 8vw, 160px)
-    clamp(60px, 18vh, 160px)
-    clamp(24px, 8vw, 160px);
-  color: var(--text-muted);
-}
-
-.site-footer__inner {
+.grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: clamp(28px, 4vw, 60px);
-  width: min(960px, 100%);
-  margin: 0 auto;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
-.site-footer__column {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+.card {
+  border: 1px solid var(--accent);
+  padding: clamp(1.5rem, 2.5vw, 2.75rem);
+  background: rgba(5, 5, 5, 0.6);
+  backdrop-filter: blur(6px);
+  display: grid;
+  gap: 1rem;
+  min-height: 240px;
+  transition: border-color 200ms ease, transform 200ms ease;
 }
 
-.site-footer__column h2 {
+.card:hover,
+.card:focus-within {
+  border-color: rgba(255, 255, 255, 0.35);
+  transform: translateY(-4px);
+}
+
+.card h3 {
   margin: 0;
-  font-family: var(--font-sans);
-  font-size: clamp(12px, 0.95vw, 15px);
-  letter-spacing: 0.34em;
+  font-family: var(--serif);
+  font-weight: 500;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--text-subtle);
+  font-size: clamp(1.1rem, 2.3vw, 1.4rem);
+  color: rgba(255, 255, 255, 0.85);
 }
 
-.site-footer__column a {
-  font-family: var(--font-serif);
-  font-size: clamp(18px, 1.8vw, 26px);
+.card p {
+  margin: 0;
+  font-size: var(--body-size);
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.footer {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  padding-top: clamp(1.5rem, 3vw, 2.5rem);
+  border-top: 1px solid var(--accent);
+}
+
+.footer__inner {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.footer__column {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.footer__column h2 {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
   font-weight: 500;
-  color: var(--text-strong);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.footer__column a {
+  color: var(--foreground);
   text-decoration: none;
+  font-size: 1rem;
   transition: color 200ms ease;
 }
 
-.site-footer__column a:hover,
-.site-footer__column a:focus-visible {
-  color: rgba(255, 255, 255, 0.9);
+.footer__column a:hover,
+.footer__column a:focus {
+  color: #ffffff;
 }
 
-.site-footer__column a:focus-visible {
-  outline: 2px solid rgba(255, 255, 255, 0.35);
-  outline-offset: 3px;
+.footer__note {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.5);
 }
 
-@media (max-width: 720px) {
-  .site-header {
-    padding: clamp(36px, 14vh, 80px) clamp(20px, 10vw, 40px);
+@media (max-width: 900px) {
+  .hero {
+    grid-template-columns: 1fr;
+    text-align: left;
   }
 
-  .site-header__inner {
-    gap: clamp(24px, 8vw, 40px);
-  }
-
-  .site-brand {
-    font-size: clamp(22px, 8.4vw, 36px);
-    letter-spacing: 0.045em;
-  }
-
-  .site-menu-toggle {
-    top: calc(var(--safe-top) + clamp(20px, 9vw, 36px));
-    right: calc(var(--safe-right) + clamp(20px, 9vw, 36px));
-    width: clamp(40px, 14vw, 52px);
-    height: clamp(40px, 14vw, 52px);
-  }
-
-  .site-menu-toggle__icon {
-    width: clamp(18px, 7vw, 24px);
-    height: clamp(12px, 5.6vw, 18px);
-  }
-
-  #sentences {
-    padding: clamp(48px, 16vh, 120px) clamp(20px, 9vw, 52px) clamp(200px, 56vh, 360px);
-  }
-
-  .sentence {
-    min-height: 82vh;
-  }
-
-  .site-menu {
-    padding:
-      calc(var(--overscroll-bleed) + clamp(20px, 8vw, 64px))
-      clamp(20px, 8vw, 64px)
-      calc(var(--overscroll-bleed) + clamp(20px, 8vw, 64px))
-      clamp(20px, 8vw, 64px);
-  }
-
-  .site-menu__container {
-    width: 100%;
-    padding: clamp(32px, 12vw, 56px) clamp(18px, 8vw, 36px);
-    border-radius: clamp(20px, 8vw, 32px);
-  }
-
-  .site-menu__list {
-    gap: clamp(20px, 8vw, 48px);
+  .hero__logo {
+    font-size: clamp(4rem, 22vw, 7.5rem);
   }
 }
 
-@media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-    scroll-behavior: auto !important;
+@media (max-width: 600px) {
+  .page {
+    padding: clamp(20px, 6vw, 32px);
+  }
+
+  .card {
+    min-height: 0;
   }
 }


### PR DESCRIPTION
## Summary
- replace the previous scroll narrative page with a LoveFrom-inspired single screen layout
- introduce a serif-led hero treatment, descriptive practice cards, and a simplified footer
- refresh global styling with minimalist dark theme, typography, and responsive tweaks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9218138b48331af1db88a46ceaa62